### PR TITLE
CheckGitHubAppMiddleware and basic admin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,26 @@ Communication from GitHub to this add-on is via webhooks.
 
 Add-on behavior:
 
-- Existing & newly created repositories are added as products in Kiwi TCMS
-- Fork repositories are NOT added as products in Kiwi TCMS
+- Auto-configure which tenant to use for database operations, either
+  'public' or a single private tenant to which user has access.
+- If unable to auto-configure display warning and redirect to configuration
+  page once the GitHub account who installed this integration onto their
+  GitHub repository logs into Kiwi TCMS
+- Existing & newly created repositories are added as products in Kiwi TCMS.
+  Fork repositories are skipped
+
+
+
+Installation
+------------
+
+::
+
+    pip install kiwitcms-github-app
+
+Then make sure the following settings are configured::
+
+    MIDDLEWARE.append('tcms_github_app.middleware.CheckGitHubAppMiddleware')
 
 
 Changelog

--- a/tcms_github_app/admin.py
+++ b/tcms_github_app/admin.py
@@ -6,6 +6,9 @@ from django.urls import reverse
 from django.contrib import admin
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 
+from social_django.models import UserSocialAuth
+
+from tcms_github_app.models import AppInstallation
 from tcms_github_app.models import WebhookPayload
 
 
@@ -30,4 +33,23 @@ class WebhookPayloadAdmin(admin.ModelAdmin):
             reverse('admin:tcms_github_app_webhookpayload_changelist'))
 
 
+class AppInstallationAdmin(admin.ModelAdmin):
+    list_display = ('pk', 'installation', 'sender', 'tenant_pk')
+    ordering = ['-installation']
+
+    def has_change_permission(self, request, obj=None):
+        if request.user.is_superuser:
+            return True
+
+        if not obj:
+            return False
+
+        social_user = UserSocialAuth.objects.filter(user=request.user).first()
+        if not social_user:
+            return False
+
+        return obj.sender == int(social_user.uid)
+
+
 admin.site.register(WebhookPayload, WebhookPayloadAdmin)
+admin.site.register(AppInstallation, AppInstallationAdmin)

--- a/tcms_github_app/middleware.py
+++ b/tcms_github_app/middleware.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2019 Alexander Todorov <atodorov@MrSenko.com>
+
+# Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
+# pylint: disable=too-few-public-methods
+
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from social_django.models import UserSocialAuth
+
+from tcms_github_app.models import AppInstallation
+
+
+class CheckGitHubAppMiddleware:
+    """
+        Warns the user and redirects them to configure their GitHub App
+        installation so it knows on which tenant to create new objects in DB.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not request.user.is_authenticated or request.method != "GET":
+            return self.get_response(request)
+
+        app_inst = None
+        social_user = UserSocialAuth.objects.filter(user=request.user).first()
+        if social_user:
+            app_inst = AppInstallation.objects.filter(
+                sender=social_user.uid,
+                tenant_pk=None
+            ).first()
+
+        if app_inst:
+            admin_path = reverse('admin:tcms_github_app_appinstallation_change',
+                                 args=[app_inst.pk])
+            if request.path != admin_path:
+                messages.add_message(
+                    request,
+                    messages.WARNING,
+                    _('Unconfigured GitHub App %d') % app_inst.installation,
+                    fail_silently=True)
+                return HttpResponseRedirect(admin_path)
+
+        return self.get_response(request)

--- a/tcms_github_app/models.py
+++ b/tcms_github_app/models.py
@@ -45,3 +45,6 @@ class AppInstallation(models.Model):
     sender = models.PositiveIntegerField(db_index=True)
     # None - means unconfigured tenant, otherwise has value
     tenant_pk = models.PositiveIntegerField(null=True, blank=True, db_index=True)
+
+    def __str__(self):
+        return "GitHub App %d" % self.installation

--- a/tcms_github_app/tests/test_middleware.py
+++ b/tcms_github_app/tests/test_middleware.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2019 Alexander Todorov <atodorov@MrSenko.com>
+
+# Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
+# pylint: disable=too-many-ancestors
+
+from django.test import modify_settings
+from django.urls import reverse
+
+from tcms_tenants.tests import LoggedInTestCase
+
+from tcms_github_app.tests import AppInstallationFactory
+from tcms_github_app.tests import UserSocialAuthFactory
+
+
+class CheckGitHubAppMiddlewareTestCase(LoggedInTestCase):
+    @modify_settings(MIDDLEWARE={
+        'append': 'tcms_github_app.middleware.CheckGitHubAppMiddleware',
+    })
+    def test_nothing_for_anonymous_user(self):
+        self.client.logout()
+
+        response = self.client.get('/', follow=True)
+
+        self.assertContains(response, 'Welcome Guest')
+        self.assertNotContains(response, 'Unconfigured GitHub App')
+
+    @modify_settings(MIDDLEWARE={
+        'append': 'tcms_github_app.middleware.CheckGitHubAppMiddleware',
+    })
+    def test_redirects_when_unconfigured_installation(self):
+        # simulate unconfigured installation
+        social_user = UserSocialAuthFactory(user=self.tester)
+        app_inst = AppInstallationFactory(sender=int(social_user.uid))
+        expected_url = reverse('admin:tcms_github_app_appinstallation_change',
+                               args=[app_inst.pk])
+
+        response = self.client.get('/', follow=True)
+
+        self.assertRedirects(response, expected_url)
+        self.assertContains(response, 'Unconfigured GitHub App %d' % app_inst.installation)
+
+    @modify_settings(MIDDLEWARE={
+        'append': 'tcms_github_app.middleware.CheckGitHubAppMiddleware',
+    })
+    def test_nothing_when_user_doesnt_have_social_auth(self):
+        # simulate unconfigured installation but the current user
+        # created his account via email/password, not GitHub so we
+        # can't match the GitHub uid !
+        AppInstallationFactory(sender=999999)
+
+        response = self.client.get('/')
+
+        self.assertContains(response, 'Kiwi TCMS - Dashboard')
+        self.assertNotContains(response, 'Unconfigured GitHub App')
+
+    @modify_settings(MIDDLEWARE={
+        'append': 'tcms_github_app.middleware.CheckGitHubAppMiddleware',
+    })
+    def test_nothing_when_unconfigured_installation_not_owned_by_user(self):
+        # simulate unconfigured installation by another user
+        social_user = UserSocialAuthFactory()
+        AppInstallationFactory(sender=int(social_user.uid))
+
+        response = self.client.get('/')
+
+        self.assertContains(response, 'Kiwi TCMS - Dashboard')
+        self.assertNotContains(response, 'Unconfigured GitHub App')


### PR DESCRIPTION
this middleware will warn & redirect users to configure their
integration with GitHub. And we don't take NO for an answer.

- admin allows users to edit only their own apps, otherwise 403