### PR TITLE
PyGithub is a runtime dependency, not devel one

### DIFF
--- a/devel.txt
+++ b/devel.txt
@@ -4,7 +4,6 @@ factory_boy
 flake8
 coverage
 kiwitcms-django-plugin
-PyGithub
 pylint
 pylint-django
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyGithub==1.57
 social-auth-app-django
 social-auth-core>=3.3.0
 kiwitcms-tenants


### PR DESCRIPTION
pin the version as well so that we can be alerted by Dependabot when it changes. This package has been a source of incompatibilities which I'd like to keep an eye on.