### PR TITLE
Build & test with Python 3.12 and Django 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ pylint:
 	if [ ! -d "$(KIWI_INCLUDE_PATH)/kiwi_lint" ]; then \
 	    git clone --depth 1 https://github.com/kiwitcms/Kiwi.git $(KIWI_INCLUDE_PATH); \
 	    pip install -U -r $(KIWI_INCLUDE_PATH)/requirements/base.txt; \
-	    pip install -U -r requirements.txt; --index-url https://$(PKG_TOKEN)@pkg.kiwitcms.eu/pypi/ --extra-index-url https://pypi.org/simple/; \
+	    pip install -U -r requirements.txt --index-url https://$(PKG_TOKEN)@pkg.kiwitcms.eu/pypi/ --extra-index-url https://pypi.org/simple/; \
 	    rm -rf $(PATH_TO_SITE_PACKAGES)/test_project; \
 	fi
 
@@ -46,7 +46,7 @@ test_for_missing_migrations:
 	if [ ! -d "$(KIWI_INCLUDE_PATH)/kiwi_lint" ]; then \
 	    git clone --depth 1 https://github.com/kiwitcms/Kiwi.git $(KIWI_INCLUDE_PATH); \
 	    pip install -U -r $(KIWI_INCLUDE_PATH)/requirements/base.txt; \
-	    pip install -U -r requirements.txt; --index-url https://$(PKG_TOKEN)@pkg.kiwitcms.eu/pypi/ --extra-index-url https://pypi.org/simple/; \
+	    pip install -U -r requirements.txt --index-url https://$(PKG_TOKEN)@pkg.kiwitcms.eu/pypi/ --extra-index-url https://pypi.org/simple/; \
 	    rm -rf $(PATH_TO_SITE_PACKAGES)/test_project; \
 	fi
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,14 @@ Then configure how the application interacts with GitHub:
 Changelog
 ---------
 
+v2.3.0 (17 Jun 2026)
+~~~~~~~~~~~~~~~~~~~~
+
+- Build and test with Django 6
+- Require Python 3.12 or newer
+- Add django.contrib.postgres to INSTALLED_APPS
+
+
 v2.2.2 (04 Jun 2026)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ cryptography>=46.0.5 # not directly required, pinned by Snyk to avoid a vulnerab
 pyjwt>=2.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.4 # not directly required, pinned by Snyk to avoid a vulnerability
 sqlparse>=0.5.4 # not directly required, pinned by Snyk to avoid a vulnerability
-django>=5.0.14 # not directly required, pinned by Snyk to avoid a vulnerability
+django>=6.0 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.6.3 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name='kiwitcms-github-app',
-    version='2.2.2',
+    version='2.3.0',
     description='GitHub App integration for Kiwi TCMS',
     long_description=get_long_description(),
     author='Kiwi TCMS',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     url='https://github.com/kiwitcms/github-app/',
     license='AGPLv3+',
     install_requires=get_install_requires('requirements.txt'),
+    python_requires='>=3.12',
     packages=find_packages(exclude=['test_project*', '*.tests']),
     zip_safe=False,
     include_package_data=True,
@@ -47,6 +48,7 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.12',
+        'Framework :: Django :: 6.0',
     ],
     entry_points={"kiwitcms.plugins": ["kiwitcms_github_app = tcms_github_app"]},
 )

--- a/tcms_settings_dir/github_app.py
+++ b/tcms_settings_dir/github_app.py
@@ -10,3 +10,6 @@ if 'tcms_github_app.middleware.CheckGitHubAppMiddleware' not in MIDDLEWARE:   # 
 
 if 'tcms_github_app.issues.Integration' not in EXTERNAL_BUG_TRACKERS:   # noqa: F821
     EXTERNAL_BUG_TRACKERS.append('tcms_github_app.issues.Integration')  # noqa: F821
+
+if 'django.contrib.postgres' not in INSTALLED_APPS:  # noqa: F821
+    INSTALLED_APPS.append('django.contrib.postgres')  # noqa: F821


### PR DESCRIPTION
Build & test against a minimum of Python 3.12 and Django 6 (latest kiwitcms/Kiwi from the master branch, which now pins Django 6.0).

- Declare `python_requires=">=3.12"`
- Add `Framework :: Django :: 6.0` classifier$\n- Bump `django` floor from `>=5.0.14` to `>=6.0`