### PR TITLE
Remove version field from docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
     db:
         container_name: postgresql_database


### PR DESCRIPTION
Docker Compose version field is deprecated and no longer needed.